### PR TITLE
Callbacks aren't required by mongoose, so don't fail without callbacks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,9 @@ mongoose.Model.prototype.save = function(cb) {
             function attemptSave() {
                 idInfo.generator(idInfo.generatorOptions, function(err, id) {
                     if (err) {
-                        cb(err);
+                        if (cb) {
+                            cb(err);
+                        }
                         return;
                     }
                     self[fieldName] = id;
@@ -28,7 +30,9 @@ mongoose.Model.prototype.save = function(cb) {
                             attemptSave();
                         } else {
                             // TODO check these args
-                            cb(err, obj);
+                            if (cb) {
+                                cb(err, obj);
+                            }
                         }
                     });
                 });


### PR DESCRIPTION
This is something of a corner case, because in pretty much all code you'll want to pass in a callback so that you know whether your save succeeded. I had some lazy test code that failed here, and since Mongoose supports no callback, I thought it made sense for this to as well.