### PR TITLE
Fix for node version 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mongoose"
   ],
   "dependencies": {
-    "bignum": "~0.6.1"
+    "bignum": "~0.9"
   },
   "peerDependencies": {
     "mongoose": ">= 3.5.0 < 4"


### PR DESCRIPTION
Updated the version number of the bignum package dependency to ~0.9.